### PR TITLE
Add AI evidence analysis to project

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.Data.SqlClient;
+using Microsoft.Data.SqlClient;
 using System.Data;
 using System.Linq;
 using QRCoder;
@@ -145,6 +145,80 @@ app.MapGet("/api/preload", async () =>
         khoaHoc = khoaHoc,
         hoatDongTruong = hoatDongTruong
     });
+});
+
+// AI: Kiểm tra video minh chứng
+app.MapPost("/api/ai/check-video", async (HttpRequest req) =>
+{
+	try
+	{
+		if (!req.HasFormContentType)
+		{
+			return Results.BadRequest(new { message = "Yêu cầu phải là multipart/form-data" });
+		}
+
+		var form = await req.ReadFormAsync();
+		var file = form.Files.GetFile("video");
+		var name = form["name"].ToString();
+		var desc = form["desc"].ToString();
+
+		if (file == null || file.Length == 0)
+		{
+			return Results.BadRequest(new { message = "Thiếu file video" });
+		}
+
+		var webRoot = app.Environment.WebRootPath ?? "wwwroot";
+		var evidenceDir = System.IO.Path.Combine(webRoot, "evidence");
+		System.IO.Directory.CreateDirectory(evidenceDir);
+
+		var ext = System.IO.Path.GetExtension(file.FileName);
+		var stamp = DateTime.UtcNow.ToString("yyyyMMdd_HHmmss");
+		var guid = Guid.NewGuid().ToString("N").Substring(0, 8);
+		var newFileName = $"{stamp}_{guid}{ext}";
+		var savePath = System.IO.Path.Combine(evidenceDir, newFileName);
+
+		using (var fs = new System.IO.FileStream(savePath, System.IO.FileMode.Create))
+		{
+			await file.CopyToAsync(fs);
+		}
+
+		var sizeMb = file.Length / 1024d / 1024d;
+		var verdict = sizeMb >= 0.2 ? "Hợp lệ" : "Không rõ ràng";
+		var explanation = sizeMb >= 0.2
+			? "Video có dung lượng đủ lớn, khả năng là minh chứng hợp lệ."
+			: "Video quá ngắn/nhẹ, có thể không đủ để xác minh.";
+
+		using var con = new SqlConnection(connStr);
+		await con.OpenAsync();
+
+		var notes = $"Tên: {name}; Mô tả: {desc}; SizeMB: {sizeMb:F2}";
+		using (var cmd = new SqlCommand(@"INSERT INTO ActivityEvidence
+			(RegistrationId, VideoFileName, VideoPath, VideoSize, Duration, Status, Notes)
+			VALUES (@reg, @fn, @path, @size, @dur, @status, @notes);", con))
+		{
+			cmd.Parameters.Add(new SqlParameter("@reg", DBNull.Value));
+			cmd.Parameters.Add(new SqlParameter("@fn", newFileName));
+			cmd.Parameters.Add(new SqlParameter("@path", $"/evidence/{newFileName}"));
+			cmd.Parameters.Add(new SqlParameter("@size", file.Length));
+			cmd.Parameters.Add(new SqlParameter("@dur", DBNull.Value));
+			cmd.Parameters.Add(new SqlParameter("@status", "PENDING"));
+			cmd.Parameters.Add(new SqlParameter("@notes", (object?)notes ?? DBNull.Value));
+			await cmd.ExecuteNonQueryAsync();
+		}
+
+		await LogAsync(app.Services.GetRequiredService<IHttpContextAccessor>()?.HttpContext!, con, "AI_CHECK_VIDEO");
+
+		return Results.Ok(new
+		{
+			message = $"{verdict}. {explanation}",
+			path = $"/evidence/{newFileName}",
+			sizeBytes = file.Length
+		});
+	}
+	catch (Exception ex)
+	{
+		return Results.BadRequest(new { message = "Lỗi xử lý video", error = ex.Message });
+	}
 });
 
 // 2.2) Đăng nhập: kiểm tra trên server (không gửi mật khẩu ra client)

--- a/README.md
+++ b/README.md
@@ -111,6 +111,9 @@ dotnet run
 - `POST /api/diem` - Thêm/sửa điểm
 - `GET /api/luutrudiemsv/ranking` - Bảng xếp hạng
 
+### AI minh chứng
+- `POST /api/ai/check-video` - Tải video minh chứng (multipart/form-data: video, name, desc). Trả về đánh giá AI sơ bộ và lưu file vào `/wwwroot/evidence/` đồng thời ghi nhận vào bảng `ActivityEvidence`.
+
 ### Hoạt động
 - `GET /api/preload` - Dữ liệu cơ bản (khoa, lớp, hoạt động)
 - `POST /api/hoatdong` - Thêm hoạt động mới


### PR DESCRIPTION
Add AI evidence analysis feature with a new API endpoint for video upload and storage.

This PR introduces a placeholder AI analysis (based on video file size) to demonstrate the integration. The 'AI' logic can be replaced with a more sophisticated model later. The new endpoint (`/api/ai/check-video`) handles `multipart/form-data` for video, saves it to `wwwroot/evidence`, and logs details to `ActivityEvidence`.

---
<a href="https://cursor.com/background-agent?bcId=bc-b88b4c3a-c1e6-410b-b309-1206d98286d1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b88b4c3a-c1e6-410b-b309-1206d98286d1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

